### PR TITLE
Unfortify games-arcade/srb2 and games-action/srb2kart

### DIFF
--- a/games-action/srb2kart/srb2kart-1.3.ebuild
+++ b/games-action/srb2kart/srb2kart-1.3.ebuild
@@ -43,7 +43,7 @@ REQUIRED_USE="
 
 src_unpack(){
 	unpack ${A}
-	7z x ${DISTDIR}/srb2kart-v${PV//./}-Installer.exe
+	7z x "${DISTDIR}/srb2kart-v${PV//./}-Installer.exe"
 }
 
 src_compile(){
@@ -82,7 +82,7 @@ src_compile(){
 	SYSFLAG="LINUX"
 	if use amd64 || use arm64 ;then SYSFLAG="LINUX64"
 	fi
-	emake SYSFLAG=1 NOUPX=1 NOVERSION=1 ${OPTIONS}
+	emake CPPFLAGS+="-D_FORTIFY_SOURCE=0" SYSFLAG=1 NOUPX=1 NOVERSION=1 ${OPTIONS}
 
 }
 

--- a/games-arcade/srb2/srb2-2.2.8.ebuild
+++ b/games-arcade/srb2/srb2-2.2.8.ebuild
@@ -80,7 +80,7 @@ src_compile(){
 	if use amd64 || use arm64 ;then IS64BIT="64"
 	fi
 	# do not upx binary, do not use version script (optional: show warnings, be verbose)
-	emake LINUX$IS64BIT=1 NOUPX=1 NOVERSION=1 ${OPTIONS} #WARNINGMODE=1 ECHO=1
+	emake CPPFLAGS+="-D_FORTIFY_SOURCE=0" LINUX$IS64BIT=1 NOUPX=1 NOVERSION=1 ${OPTIONS} #WARNINGMODE=1 ECHO=1
 
 }
 


### PR DESCRIPTION
GCC's `FORTIFY_SOURCE` causes issues on some servers ( bug #8 ). Build the SRB2 packages with `CPPFLAGS+="-D_FORTIFY_SOURCE=0"`.

This might pose a security risk.